### PR TITLE
Add notes for building on macOS and fix typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# macOS
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 build16: pico-sdk changeto16 quick
 
-build2: pico-sdk changeto2 quick 
+build2: pico-sdk changeto2 quick
 
 prereqs: pico-sdk
+ifeq ($(shell uname),Darwin)
+	brew install clang-format cmake gcc minicom sox python3
+	brew install --cask gcc-arm-embedded
+	python3 -m pip install matplotlib numpy icecream
+else
 	sudo apt install -y clang-format cmake gcc-arm-none-eabi gcc g++ minicom sox python3 python3-pip
-	sudo -H python3 -m pip install matplotlib numpy
+	sudo -H python3 -m pip install matplotlib numpy icecream
+endif
 
 doth/easing.h:
 	cd doth && python3 generate_easing.py > easing.h
@@ -21,10 +27,18 @@ quick: doth/easing.h doth/filter.h
 	echo "BUILD SUCCESS"
 
 changeto16:
+ifeq ($(shell uname),Darwin)
+	sed -i '' 's/LENGTH = 2048k/LENGTH = 16384k/g' pico-sdk/src/rp2_common/pico_standard_link/memmap_default.ld
+else
 	sed -i 's/LENGTH = 2048k/LENGTH = 16384k/g' pico-sdk/src/rp2_common/pico_standard_link/memmap_default.ld
+endif
 
 changeto2:
+ifeq ($(shell uname),Darwin)
+	sed -i '' 's/LENGTH = 16384k/LENGTH = 2048k/g' pico-sdk/src/rp2_common/pico_standard_link/memmap_default.ld
+else
 	sed -i 's/LENGTH = 16384k/LENGTH = 2048k/g' pico-sdk/src/rp2_common/pico_standard_link/memmap_default.ld
+endif
 
 audio:
 	cd audio2h && rm -rf converted
@@ -33,10 +47,10 @@ audio:
 
 clean:
 	rm -rf build
-	rm -rf doth/easing.h 
+	rm -rf doth/easing.h
 	rm -rf doth/filter.h
 	rm -rf doth/audio2h.h
-	rm -rf audio2h/converted 
+	rm -rf audio2h/converted
 	rm -rf audio2h/files.json
 
 pico-sdk:

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # pikocore
 
 
-pikocore is a hackable, open-source, lo-fi music mangler based on the Raspberry Pi Pico. 
+pikocore is a hackable, open-source, lo-fi music mangler based on the Raspberry Pi Pico.
 
 read more here: https://pikocore.com
 
 
 ## usage
 
-### prerequisites 
+### prerequisites
 
 First install Go and then install pre-reqs:
 
 ```
-make preqreqs
+make prereqs
 ```
 
 This will install `clang-format`, `cmake`, the pico toolchain, `gcc`, `python`, and other useful packages.


### PR DESCRIPTION
This just cleans up some white space and fixes a typo in the README, as well as adding some macOS specific fixes around `sed` use, the missing `icecream` pip dependency, and some trailing whitespace on some lines.

The error around sed seems to be macOS specific and Apple has a long history of having a slightly different sed, the issue is around the missing backup file extension:

```sh
make changeto16
sed -i 's/LENGTH = 2048k/LENGTH = 16384k/g' pico-sdk/src/rp2_common/pico_standard_link/memmap_default.ld
sed: 1: "pico-sdk/src/rp2_common ...": extra characters at the end of p command
make: *** [changeto16] Error 1
```

Currently building on macOS 13.5 (22G74) successfully after applying these updates.