### PR TITLE
Remove python icecream library dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ prereqs: pico-sdk
 ifeq ($(shell uname),Darwin)
 	brew install clang-format cmake gcc minicom sox python3
 	brew install --cask gcc-arm-embedded
-	python3 -m pip install matplotlib numpy icecream
+	python3 -m pip install matplotlib numpy
 else
 	sudo apt install -y clang-format cmake gcc-arm-none-eabi gcc g++ minicom sox python3 python3-pip
-	sudo -H python3 -m pip install matplotlib numpy icecream
+	sudo -H python3 -m pip install matplotlib numpy
 endif
 
 doth/easing.h:

--- a/doth/biquad.py
+++ b/doth/biquad.py
@@ -1,6 +1,4 @@
 import math
-from icecream import ic
-
 
 # https://stackoverflow.com/questions/52547218/how-to-caculate-biquad-filter-coefficient
 def coefficients(FC, FS, Q, dB, lowpass=True, ROUNDER=20):
@@ -35,8 +33,6 @@ def coefficients(FC, FS, Q, dB, lowpass=True, ROUNDER=20):
     a1 = round((1 << ROUNDER) * a1)
     a2 = round((1 << ROUNDER) * a2)
 
-    # ic(FC, FS, Q, dB)
-    # ic(a1, a2, b0, b1, b2)
     return (a1, a2, b0, b1, b2)
 
 


### PR DESCRIPTION
The icecream debugging library was required by doth/biquad.py. That file imported icecream so it could not run without the library present. However, aside from importing it, it did not use the library. This commit removes the import statement so that there is one less dependency to install.