### PR TITLE
fix: guard sequencer recording against buffer overflow

### DIFF
--- a/doth/sequencer.h
+++ b/doth/sequencer.h
@@ -25,6 +25,12 @@ class Sequencer {
       mem[i] = save_data_[i + 100];
     }
     len = save_data_[98];
+    // Record() could push len past the end of mem, and Save() persists it, so a
+    // page written by older firmware can restore an out of range length. Start
+    // empty rather than indexing past mem.
+    if (len > sizeof(mem)) {
+      len = 0;
+    }
     if (save_data_[99] == 1) {
       isPlaying = true;
     }
@@ -42,8 +48,11 @@ class Sequencer {
     }
   }
 
+  // len is a uint8_t and mem is 128 bytes, so an unbounded recording runs off
+  // the end of the object and into whatever follows it in memory. Stop at the
+  // end of the buffer instead.
   void Record(uint8_t v) {
-    if (isRecording) {
+    if (isRecording && len < sizeof(mem)) {
       mem[len] = v;
       len++;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,5 +11,10 @@ add_executable(clock_sync_test
 target_include_directories(clock_sync_test PRIVATE ../src)
 target_compile_options(clock_sync_test PRIVATE -Wall -Wextra -Werror)
 
+add_executable(sequencer_test sequencer_test.cpp)
+target_include_directories(sequencer_test PRIVATE ../doth)
+target_compile_options(sequencer_test PRIVATE -Wall -Wextra -Werror)
+
 enable_testing()
 add_test(NAME clock_sync_test COMMAND clock_sync_test)
+add_test(NAME sequencer_test COMMAND sequencer_test)

--- a/tests/sequencer_test.cpp
+++ b/tests/sequencer_test.cpp
@@ -1,0 +1,103 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+// sequencer.h is a bare header meant to be included after the firmware's flash
+// constants; 256 matches FLASH_PAGE_SIZE on the RP2040.
+#define FLASH_PAGE_SIZE 256
+#include "sequencer.h"
+
+namespace {
+
+constexpr int kGuard = 64;
+constexpr uint8_t kGuardByte = 0xA5;
+
+// mem is the last member of Sequencer, so a run off its end lands in whatever
+// follows the object. This puts something recognisable there.
+struct Harness {
+  Sequencer seq;
+  uint8_t guard[kGuard];
+
+  Harness() {
+    memset(guard, kGuardByte, sizeof(guard));
+    seq.Init();
+  }
+
+  void assertGuardIntact() const {
+    for (int i = 0; i < kGuard; i++) {
+      assert(guard[i] == kGuardByte);
+    }
+  }
+};
+
+// Recording longer than the buffer must stop, not keep writing.
+void testRecordStopsAtBufferEnd() {
+  Harness h;
+  h.seq.SetRecording(true);
+  for (int i = 0; i < 400; i++) {
+    h.seq.Record((uint8_t)(i % 8));
+  }
+  h.assertGuardIntact();
+
+  // Everything written is still readable, and playback stays inside it.
+  h.seq.SetPlaying(true);
+  for (uint32_t beat = 0; beat < 1000; beat++) {
+    assert(h.seq.Next(beat) < 8);
+  }
+}
+
+// The unbounded Record() could leave len anywhere up to 255, and Save() writes
+// it to flash, so units running the old firmware have out of range lengths
+// sitting in their settings page. Loading one must not index past mem.
+void testLoadRejectsOversizedLength() {
+  const uint8_t bad_lengths[] = {129, 200, 255};
+  for (uint8_t bad : bad_lengths) {
+    Harness h;
+    uint8_t save_data[FLASH_PAGE_SIZE];
+    memset(save_data, 0, sizeof(save_data));
+    save_data[98] = bad;
+    save_data[99] = 1;  // saved mid-playback
+    h.seq.Load(save_data);
+    h.assertGuardIntact();
+    // The length was rejected, so there is nothing to play whatever byte 99 said.
+    assert(!h.seq.IsPlaying());
+    assert(h.seq.Last() == 255);
+    for (uint32_t beat = 0; beat < 512; beat++) {
+      assert(h.seq.Next(beat) == 0);
+    }
+  }
+}
+
+// A length that was genuinely saved must survive the round trip untouched.
+void testSaveLoadRoundTrip() {
+  Harness h;
+  h.seq.SetRecording(true);
+  for (uint8_t i = 0; i < 5; i++) {
+    h.seq.Record(i);
+  }
+  h.seq.SetPlaying(true);
+
+  uint8_t save_data[FLASH_PAGE_SIZE];
+  memset(save_data, 0, sizeof(save_data));
+  h.seq.Save(save_data);
+
+  Harness loaded;
+  loaded.seq.Load(save_data);
+  assert(loaded.seq.IsPlaying());
+  assert(loaded.seq.Last() == 4);
+  for (uint32_t beat = 0; beat < 5; beat++) {
+    assert(loaded.seq.Next(beat) == beat);
+  }
+  loaded.assertGuardIntact();
+}
+
+}  // namespace
+
+int main(void) {
+  testRecordStopsAtBufferEnd();
+  testLoadRejectsOversizedLength();
+  testSaveLoadRoundTrip();
+  printf("sequencer_test: all assertions passed\n");
+  return 0;
+}


### PR DESCRIPTION
# Symptom
Pikocore hangs when recording a long sequence & when playing back recorded sequence that initially caused the hang.

# Cause
`mem` is the last member of the class, so once the 129th beat is recorded the writes land in whatever follows the `Sequencer` object in memory. `sequencer` is a global in `main.cpp`, so the writes go into adjacent globals.

Reachable when 128 recorded beats with sequencer armed.

Out of range length also survived reboot and caused the hang on playback.

# Changes
- `Record()` stops writing at the end of `mem` instead of running off the end.
- `Load()` clamps an out of range saved length back to 0, so a page saved by the current firmware with a bad length recovers to an empty sequence instead of reading past the buffer.
- Adds `tests/sequencer_test.cpp` covering both cases plus a save/load round trip.


